### PR TITLE
Fix PageSpeed Insights link

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -99,7 +99,7 @@ const Footer: FC = () => {
           Gatsby-built, Netlify-hosted,{' '}
           <span sx={{ display: [`block`, `inline`] }}>
             <a
-              href="https://pagespeed.web.dev/analysis/https-chrisnager-com/w1qevz18f5?form_factor=desktop"
+              href="https://pagespeed.web.dev/analysis/https-chrisnager-com/yy2myyue87?form_factor=mobile"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Summary
- update the PageSpeed Insights URL in the site footer

## Testing
- `yarn lint` *(fails: Invalid option `--ext`)*
- `yarn typecheck` *(fails: cannot find modules and JSX errors)*

------
https://chatgpt.com/codex/tasks/task_e_6885a24d2884832bb1c4f79ff71325fa