### PR TITLE
DOOM MCP app teaser

### DIFF
--- a/src/data/features.yml
+++ b/src/data/features.yml
@@ -1,3 +1,7 @@
+- category: Projects
+  title: 'Playable DOOM in an MCP app'
+  link: 'https://github.com/chrisnager/chrisnager-dot-com/pull/54'
+
 # - category: 'Case studies'
 #   title: 'ink Design System'
 #   link: '/projects/ink'


### PR DESCRIPTION
## Summary

This change adds a homepage feature that points to the DOOM MCP app pull request, serving as a teaser before a related blog post is ready.